### PR TITLE
Add missing \b

### DIFF
--- a/Wiki.py
+++ b/Wiki.py
@@ -32,10 +32,10 @@ def get_wiki(text,mic):
 
 
 def isValid(text):
-    wiki= bool(re.search(r'\Wiki\b',text, re.IGNORECASE))
+    wiki= bool(re.search(r'\bWiki\b',text, re.IGNORECASE))
     # Add 'Wicky' because the STT engine recognizes it quite often
-    wicky= bool(re.search(r'\wicky\b',text, re.IGNORECASE))
-    article= bool(re.search(r'\article\b',text, re.IGNORECASE))
+    wicky= bool(re.search(r'\bwicky\b',text, re.IGNORECASE))
+    article= bool(re.search(r'\barticle\b',text, re.IGNORECASE))
 
     if wicky or wiki or article:
         return True


### PR DESCRIPTION
I noticed in the tutorial that the example given was `r'\bmeaning of life\b'`, and in the isValid function of your module, the validity checkers were missing the first `b` and had just the backslash.

Note that I have not tested it, and I may be wrong.
