### PR TITLE
lowercased search term / simplified isValid test

### DIFF
--- a/Wiki.py
+++ b/Wiki.py
@@ -18,6 +18,8 @@ def get_wiki(text,mic):
     mic.say("What would you like to learn about?")
     # get the user voice input as string
     article_title = mic.activeListen()
+    # wikipedia api requires lowercased title
+    article_title = article_title.lower()
     # make a call to the Wikipedia API
     request = Request('https://en.wikipedia.org/w/api.php?format=json&action=query&prop=extracts&exintro=&explaintext=&titles='+article_title)
     try:
@@ -32,13 +34,4 @@ def get_wiki(text,mic):
 
 
 def isValid(text):
-    wiki= bool(re.search(r'\bWiki\b',text, re.IGNORECASE))
-    # Add 'Wicky' because the STT engine recognizes it quite often
-    wicky= bool(re.search(r'\bwicky\b',text, re.IGNORECASE))
-    article= bool(re.search(r'\barticle\b',text, re.IGNORECASE))
-
-    if wicky or wiki or article:
-        return True
-    else:
-        return False
-
+    return bool(re.search(r'\b(Wiki|wicky|article)\b',text, re.IGNORECASE))


### PR DESCRIPTION
Thanks for the great module!
I found myself hitting odd errors when trying to issue search terms with voice.  All worked perfectly using the --local flag, however voice searches consistently failed for me.

Digging into it, it seems that the Wikipedia API returns no matches when the title is passed uppercased (as is returned by mic.activeListen() ) , converting to lowercase appears to resolve this issue.

